### PR TITLE
[ FEAT ] JWT 인가 필터 구현 및 Refresh Token 기반 Access Token 재발급 처리 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,9 @@ dependencies {
     // MySQL
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     // Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 

--- a/src/main/java/com/project/chaechaeserver/application/service/user/RedisRefreshTokenService.java
+++ b/src/main/java/com/project/chaechaeserver/application/service/user/RedisRefreshTokenService.java
@@ -1,0 +1,11 @@
+package com.project.chaechaeserver.application.service.user;
+
+
+public interface RedisRefreshTokenService {
+
+    void saveRefreshToken(String email, String refreshToken);
+
+    String getRefreshToken(String email);
+
+    void deleteRefreshToken(String email);
+}

--- a/src/main/java/com/project/chaechaeserver/infrastructure/service/redis/RedisRefreshTokenServiceImpl.java
+++ b/src/main/java/com/project/chaechaeserver/infrastructure/service/redis/RedisRefreshTokenServiceImpl.java
@@ -1,0 +1,29 @@
+package com.project.chaechaeserver.infrastructure.service.redis;
+
+import com.project.chaechaeserver.application.service.user.RedisRefreshTokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class RedisRefreshTokenServiceImpl implements RedisRefreshTokenService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void saveRefreshToken(String email, String refreshToken) {
+        long refreshTokenTime = 14 * 24 * 60 * 60L;
+        redisTemplate.opsForValue().set(email, refreshToken, Duration.ofSeconds(refreshTokenTime));
+    }
+
+    public String getRefreshToken(String email) {
+        return redisTemplate.opsForValue().get(email);
+    }
+
+    public void deleteRefreshToken(String email) {
+        redisTemplate.delete(email);
+    }
+
+}

--- a/src/main/java/com/project/chaechaeserver/presentation/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/project/chaechaeserver/presentation/filter/JwtAuthorizationFilter.java
@@ -1,0 +1,117 @@
+package com.project.chaechaeserver.presentation.filter;
+
+import com.project.chaechaeserver.application.service.user.RedisRefreshTokenService;
+import com.project.chaechaeserver.domain.model.user.constraint.RoleType;
+import com.project.chaechaeserver.infrastructure.security.CustomUserDetailsService;
+import com.project.chaechaeserver.infrastructure.util.JwtUtil;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Objects;
+
+@Slf4j(topic = "JWT 검증 및 인가")
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final CustomUserDetailsService customUserDetailsService;
+    private final RedisRefreshTokenService redisRefreshTokenService;
+
+    public JwtAuthorizationFilter(JwtUtil jwtUtil, CustomUserDetailsService customUserDetailsService, RedisRefreshTokenService redisRefreshTokenService) {
+        this.jwtUtil = jwtUtil;
+        this.customUserDetailsService = customUserDetailsService;
+        this.redisRefreshTokenService = redisRefreshTokenService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain filterChain) throws ServletException, IOException {
+
+        String tokenValue = jwtUtil.getJwtFromHeader(req);
+
+        if (StringUtils.hasText(tokenValue)) {
+
+            if (!jwtUtil.validateToken(tokenValue)) {
+                log.error("Token Error");
+                refreshAccessJwt(req, res);
+                return;
+            }
+
+            Claims info = jwtUtil.getUserInfoFromToken(tokenValue);
+
+            try {
+                setAuthentication(info.getSubject());
+            } catch (Exception e) {
+                log.error(e.getMessage());
+                return;
+            }
+        }
+
+        filterChain.doFilter(req, res);
+    }
+
+    public void setAuthentication(String username) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        Authentication authentication = createAuthentication(username);
+        context.setAuthentication(authentication);
+
+        SecurityContextHolder.setContext(context);
+    }
+
+    private Authentication createAuthentication(String username) {
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername(username);
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+
+    public void refreshAccessJwt(HttpServletRequest req, HttpServletResponse res) throws IOException {
+
+        String expiredAccessJwt = jwtUtil.getJwtFromHeader(req);
+        Claims claims = jwtUtil.getUserInfoFromToken(expiredAccessJwt);
+        String email = claims.getSubject();
+        String role = claims.get(JwtUtil.AUTHORIZATION_KEY, String.class);
+
+        // Refresh Token 추출
+        String refreshJwtFromCookie = "";
+
+        Cookie[] cookies = req.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (JwtUtil.REFRESH_JWT_HEADER.equals(cookie.getName())) {
+                    refreshJwtFromCookie = cookie.getValue();
+                    break;
+                }
+            }
+        }
+
+        log.debug("Refresh Token 추출 완료");
+
+        String refreshJwtFromRedis = redisRefreshTokenService.getRefreshToken(email);
+
+        // Refresh Token 유효성 검증
+        if (!StringUtils.hasText(refreshJwtFromCookie) || !jwtUtil.validateToken(refreshJwtFromCookie) || !Objects.equals(refreshJwtFromCookie, refreshJwtFromRedis)) {
+            log.info("사용자 '{}'의 Refresh Token 만료 또는 유효하지 않음", email);
+            redisRefreshTokenService.deleteRefreshToken(email);
+            res.sendError(401, "Refresh Token이 존재하지 않거나 만료됐습니다.");
+            return;
+        }
+
+        // 새로운 AccessToken 발급
+        String newAccessJwt = jwtUtil.generateAccessJwt(email, RoleType.valueOf(role));
+
+        // 헤더를 통해 전달
+        res.addHeader(JwtUtil.ACCESS_JWT_HEADER, newAccessJwt);
+
+        log.info("사용자 '{}'의 새로운 Access Token 발급 완료", email);
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -15,6 +15,11 @@ spring:
         format_sql: true
     open-in-view: false
 
+  data:
+    redis:
+      port: ${REDIS_PORT}
+      host: ${REDIS_HOST}
+
 service:
   jwt:
     secret-key: ${JWT_SECRET_KEY}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #3 

## 📝 Description

- JWT 기반의 인가 필터를 구현하였고, `Access Token` 이 만료된 경우 `Refresh Token` 을 이용해 새로운 `Access Token` 을 재발급하는 로직을 추가했습니다.

### Access Token 재발급 예시

```
2025-06-26T20:01:32.243+09:00 ERROR 77808 --- [chae-chae-server] [nio-8080-exec-3] JwtUtil                                  : Expired JWT token, 만료된 JWT token 입니다.
2025-06-26T20:01:32.245+09:00 ERROR 77808 --- [chae-chae-server] [nio-8080-exec-3] JWT 검증 및 인가                              : Token Error
2025-06-26T20:01:32.253+09:00  INFO 77808 --- [chae-chae-server] [nio-8080-exec-3] JWT 검증 및 인가                              : 사용자 'john.doe@example2.com'의 새로운 Access Token 발급 완료
``` 

<img width="969" alt="스크린샷 2025-06-26 오후 8 20 49" src="https://github.com/user-attachments/assets/49e06aec-09c6-4bc4-9ee2-e5e9f1745e7d" />