### PR TITLE
[ FEAT ] JWT 기반 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,11 @@ dependencies {
     // Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
+    // Jwt
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
     // Web, Lombok, Valid, Test
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,9 @@ dependencies {
     // MySQL
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     // Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 

--- a/src/main/java/com/project/chaechaeserver/application/service/user/RedisRefreshTokenService.java
+++ b/src/main/java/com/project/chaechaeserver/application/service/user/RedisRefreshTokenService.java
@@ -1,0 +1,11 @@
+package com.project.chaechaeserver.application.service.user;
+
+
+public interface RedisRefreshTokenService {
+
+    void saveRefreshToken(String email, String refreshToken);
+
+    String getRefreshToken(String email);
+
+    void deleteRefreshToken(String email);
+}

--- a/src/main/java/com/project/chaechaeserver/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/project/chaechaeserver/infrastructure/config/SecurityConfig.java
@@ -1,15 +1,66 @@
 package com.project.chaechaeserver.infrastructure.config;
 
+import com.project.chaechaeserver.infrastructure.util.JwtUtil;
+import com.project.chaechaeserver.presentation.filter.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtUtil jwtUtil;
+    private final AuthenticationConfiguration authenticationConfiguration;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() throws Exception {
+        JwtAuthenticationFilter filter = new JwtAuthenticationFilter(jwtUtil);
+        filter.setAuthenticationManager(authenticationManager(authenticationConfiguration));
+        return filter;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+
+        http.csrf((csrf) -> csrf.disable());
+
+        http.sessionManagement((sessionManagement) ->
+                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+        );
+
+        http.authorizeHttpRequests((authorizeHttpRequests) ->
+                authorizeHttpRequests
+                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                        .requestMatchers("/").permitAll()
+                        .requestMatchers("//api/users/login").permitAll()
+                        .requestMatchers("/api/users/signup").permitAll()
+                        .anyRequest().authenticated()
+        );
+
+        http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
     }
 }

--- a/src/main/java/com/project/chaechaeserver/infrastructure/security/CustomUserDetails.java
+++ b/src/main/java/com/project/chaechaeserver/infrastructure/security/CustomUserDetails.java
@@ -1,0 +1,92 @@
+package com.project.chaechaeserver.infrastructure.security;
+
+import com.project.chaechaeserver.domain.model.user.InternalUserEntity;
+import com.project.chaechaeserver.domain.model.user.constraint.RoleType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private User user;
+
+    public static CustomUserDetails of(InternalUserEntity internalUserEntity) {
+        return CustomUserDetails.builder()
+                .user(User.from(internalUserEntity))
+                .build();
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class User {
+
+        private Long id;
+        private String email;
+        private String password;
+        private RoleType role;
+
+        public static User from(InternalUserEntity internalUserEntity) {
+            return User.builder()
+                    .id(internalUserEntity.getId())
+                    .email(internalUserEntity.getEmail())
+                    .password(internalUserEntity.getPassword())
+                    .role(internalUserEntity.getRole())
+                    .build();
+        }
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        RoleType role = user.getRole();
+        String authority = role.getRole();
+
+        SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(authority);
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(simpleGrantedAuthority);
+
+        return authorities;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+}

--- a/src/main/java/com/project/chaechaeserver/infrastructure/security/CustomUserDetailsService.java
+++ b/src/main/java/com/project/chaechaeserver/infrastructure/security/CustomUserDetailsService.java
@@ -1,0 +1,27 @@
+package com.project.chaechaeserver.infrastructure.security;
+
+import com.project.chaechaeserver.domain.model.user.InternalUserEntity;
+import com.project.chaechaeserver.domain.repository.user.InternalUserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final InternalUserRepository internalUserRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+
+        InternalUserEntity internalUserEntity = internalUserRepository.findByEmailDeletedAtIsNull(email)
+                .orElseThrow(() -> new UsernameNotFoundException("이메일을 정확히 입력해주세요."));
+
+        return CustomUserDetails.of(internalUserEntity);
+    }
+}

--- a/src/main/java/com/project/chaechaeserver/infrastructure/service/redis/RedisRefreshTokenServiceImpl.java
+++ b/src/main/java/com/project/chaechaeserver/infrastructure/service/redis/RedisRefreshTokenServiceImpl.java
@@ -1,0 +1,29 @@
+package com.project.chaechaeserver.infrastructure.service.redis;
+
+import com.project.chaechaeserver.application.service.user.RedisRefreshTokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+public class RedisRefreshTokenServiceImpl implements RedisRefreshTokenService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void saveRefreshToken(String email, String refreshToken) {
+        long refreshTokenTime = 14 * 24 * 60 * 60L;
+        redisTemplate.opsForValue().set(email, refreshToken, Duration.ofSeconds(refreshTokenTime));
+    }
+
+    public String getRefreshToken(String email) {
+        return redisTemplate.opsForValue().get(email);
+    }
+
+    public void deleteRefreshToken(String email) {
+        redisTemplate.delete(email);
+    }
+
+}

--- a/src/main/java/com/project/chaechaeserver/infrastructure/util/JwtUtil.java
+++ b/src/main/java/com/project/chaechaeserver/infrastructure/util/JwtUtil.java
@@ -1,0 +1,81 @@
+package com.project.chaechaeserver.infrastructure.util;
+
+import com.project.chaechaeserver.domain.model.user.constraint.RoleType;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+@Slf4j(topic = "JwtUtil")
+public class JwtUtil {
+
+    public static final String ACCESS_JWT_HEADER = "Authorization";
+    public static final String AUTHORIZATION_KEY = "auth";
+    public static final String BEARER_PREFIX = "Bearer ";
+    private final long ACCESS_TOKEN_TIME = 60 * 60 * 1000L; // 1시간
+    private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    @Value("${service.jwt.secret-key}")
+    private String secretKey;
+    public Key key;
+
+    @PostConstruct
+    public void init() {
+        byte[] bytes = Base64.getDecoder().decode(secretKey);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    public String generateAccessJwt(String username, RoleType role) {
+        Date date = new Date();
+
+        return BEARER_PREFIX +
+                Jwts.builder()
+                        .setSubject(username)
+                        .claim(AUTHORIZATION_KEY, role)
+                        .setExpiration(new Date(date.getTime() + ACCESS_TOKEN_TIME))
+                        .setIssuedAt(date)
+                        .signWith(key, signatureAlgorithm)
+                        .compact();
+    }
+
+    public String getJwtFromHeader(HttpServletRequest request) {
+        String bearerToken = request.getHeader(ACCESS_JWT_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException | SignatureException e) {
+            log.error("Invalid JWT signature, 유효하지 않는 JWT 서명 입니다.");
+        } catch (ExpiredJwtException e) {
+            log.error("Expired JWT token, 만료된 JWT token 입니다.");
+        } catch (UnsupportedJwtException e) {
+            log.error("Unsupported JWT token, 지원되지 않는 JWT 토큰 입니다.");
+        } catch (IllegalArgumentException e) {
+            log.error("JWT claims is empty, 잘못된 JWT 토큰 입니다.");
+        }
+        return false;
+    }
+
+    public Claims getUserInfoFromToken(String token) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+}

--- a/src/main/java/com/project/chaechaeserver/presentation/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/project/chaechaeserver/presentation/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,60 @@
+package com.project.chaechaeserver.presentation.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.chaechaeserver.domain.model.user.constraint.RoleType;
+import com.project.chaechaeserver.infrastructure.security.CustomUserDetails;
+import com.project.chaechaeserver.infrastructure.util.JwtUtil;
+import com.project.chaechaeserver.presentation.request.user.ReqAuthPostLoginDTO;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.io.IOException;
+
+@Slf4j(topic = "로그인 및 JWT 생성")
+public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilter {
+    private final JwtUtil jwtUtil;
+
+    public JwtAuthenticationFilter(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+        setFilterProcessesUrl("/api/users/login");
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+        try {
+            ReqAuthPostLoginDTO dto = new ObjectMapper().readValue(request.getInputStream(), ReqAuthPostLoginDTO.class);
+
+            return getAuthenticationManager().authenticate(
+                    new UsernamePasswordAuthenticationToken(
+                            dto.getUser().getEmail(),
+                            dto.getUser().getPassword(),
+                            null
+                    )
+            );
+        } catch (IOException e) {
+            log.error(e.getMessage());
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authResult) {
+        String username = ((CustomUserDetails) authResult.getPrincipal()).getUsername();
+        RoleType role = ((CustomUserDetails) authResult.getPrincipal()).getUser().getRole();
+
+        String token = jwtUtil.generateAccessJwt(username, role);
+        response.addHeader(JwtUtil.ACCESS_JWT_HEADER, token);
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
+        response.setStatus(401);
+    }
+
+}

--- a/src/main/java/com/project/chaechaeserver/presentation/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/project/chaechaeserver/presentation/filter/JwtAuthorizationFilter.java
@@ -1,0 +1,117 @@
+package com.project.chaechaeserver.presentation.filter;
+
+import com.project.chaechaeserver.application.service.user.RedisRefreshTokenService;
+import com.project.chaechaeserver.domain.model.user.constraint.RoleType;
+import com.project.chaechaeserver.infrastructure.security.CustomUserDetailsService;
+import com.project.chaechaeserver.infrastructure.util.JwtUtil;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Objects;
+
+@Slf4j(topic = "JWT 검증 및 인가")
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final CustomUserDetailsService customUserDetailsService;
+    private final RedisRefreshTokenService redisRefreshTokenService;
+
+    public JwtAuthorizationFilter(JwtUtil jwtUtil, CustomUserDetailsService customUserDetailsService, RedisRefreshTokenService redisRefreshTokenService) {
+        this.jwtUtil = jwtUtil;
+        this.customUserDetailsService = customUserDetailsService;
+        this.redisRefreshTokenService = redisRefreshTokenService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain filterChain) throws ServletException, IOException {
+
+        String tokenValue = jwtUtil.getJwtFromHeader(req);
+
+        if (StringUtils.hasText(tokenValue)) {
+
+            if (!jwtUtil.validateToken(tokenValue)) {
+                log.error("Token Error");
+                refreshAccessJwt(req, res);
+                return;
+            }
+
+            Claims info = jwtUtil.getUserInfoFromToken(tokenValue);
+
+            try {
+                setAuthentication(info.getSubject());
+            } catch (Exception e) {
+                log.error(e.getMessage());
+                return;
+            }
+        }
+
+        filterChain.doFilter(req, res);
+    }
+
+    public void setAuthentication(String username) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        Authentication authentication = createAuthentication(username);
+        context.setAuthentication(authentication);
+
+        SecurityContextHolder.setContext(context);
+    }
+
+    private Authentication createAuthentication(String username) {
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername(username);
+        return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+    }
+
+    public void refreshAccessJwt(HttpServletRequest req, HttpServletResponse res) throws IOException {
+
+        String expiredAccessJwt = jwtUtil.getJwtFromHeader(req);
+        Claims claims = jwtUtil.getUserInfoFromToken(expiredAccessJwt);
+        String email = claims.getSubject();
+        String role = claims.get(JwtUtil.AUTHORIZATION_KEY, String.class);
+
+        // Refresh Token 추출
+        String refreshJwtFromCookie = "";
+
+        Cookie[] cookies = req.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (JwtUtil.REFRESH_JWT_HEADER.equals(cookie.getName())) {
+                    refreshJwtFromCookie = cookie.getValue();
+                    break;
+                }
+            }
+        }
+
+        log.debug("Refresh Token 추출 완료");
+
+        String refreshJwtFromRedis = redisRefreshTokenService.getRefreshToken(email);
+
+        // Refresh Token 유효성 검증
+        if (!StringUtils.hasText(refreshJwtFromCookie) || !jwtUtil.validateToken(refreshJwtFromCookie) || !Objects.equals(refreshJwtFromCookie, refreshJwtFromRedis)) {
+            log.info("사용자 '{}'의 Refresh Token 만료 또는 유효하지 않음", email);
+            redisRefreshTokenService.deleteRefreshToken(email);
+            res.sendError(401, "Refresh Token이 존재하지 않거나 만료됐습니다.");
+            return;
+        }
+
+        // 새로운 AccessToken 발급
+        String newAccessJwt = jwtUtil.generateAccessJwt(email, RoleType.valueOf(role));
+
+        // 헤더를 통해 전달
+        res.addHeader(JwtUtil.ACCESS_JWT_HEADER, newAccessJwt);
+
+        log.info("사용자 '{}'의 새로운 Access Token 발급 완료", email);
+    }
+}

--- a/src/main/java/com/project/chaechaeserver/presentation/request/user/ReqAuthPostLoginDTO.java
+++ b/src/main/java/com/project/chaechaeserver/presentation/request/user/ReqAuthPostLoginDTO.java
@@ -1,0 +1,34 @@
+package com.project.chaechaeserver.presentation.request.user;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReqAuthPostLoginDTO {
+
+    @Valid
+    @NotNull(message = "회원정보를 입력해주세요")
+    private User user;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class User {
+
+        @NotBlank(message = "이메일을 입력해주세요.")
+        private String email;
+
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        private String password;
+
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -15,6 +15,11 @@ spring:
         format_sql: true
     open-in-view: false
 
+  data:
+    redis:
+      port: ${REDIS_PORT}
+      host: ${REDIS_HOST}
+
 service:
   jwt:
     secret-key: ${JWT_SECRET_KEY}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #3 

## 📝 Description

- JWT 기반 로그인 기능을 구현했습니다.
- 로그인 요청 시 이메일, 비밀번호를 검증하고 JWT를 생성하여 응답 헤더에 포함합니다.

### 로그인 요청 예시
```json
{
  "user": {
    "email": "john.doe@example2.com",
    "password": "securePassword123!"
  }
}
```

### 로그인 응답 예시

<img width="972" alt="스크린샷 2025-06-26 오후 7 06 42" src="https://github.com/user-attachments/assets/690d529a-e927-42e7-a39a-6a129a228b78" />
