### PR TITLE
[ FEAT ] 도커 컴포즈 파일 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ build/
 !**/src/test/**/build/
 .DS_Store
 /src/main/resources/application-key.yml
-
+.env.*
 ### STS ###
 .apt_generated
 .classpath

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,33 @@
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: mysql-chae-chae
+    ports:
+      - "3306:3306"
+    env_file:
+      - ./.env.mysql
+    volumes:
+      - mysql-data:/var/lib/mysql
+    networks:
+      - chae-chae-network
+    restart: unless-stopped
+
+  redis:
+    image: redis:latest
+    container_name: redis-chae-chae
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+    networks:
+      - chae-chae-network
+    restart: unless-stopped
+
+networks:
+  chae-chae-network:
+    driver: bridge
+
+volumes:
+  mysql-data:
+  redis-data:
+

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,0 +1,13 @@
+services:
+  backend:
+    image: hyeonmin2/chae-chae-server:latest
+    env_file:
+      - ./.env.backend
+    ports:
+      - "8080:8080"
+    depends_on:
+      - mysql
+      - redis
+    networks:
+      - chae-chae-network
+    restart: unless-stopped


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- ex) #12
## 📝 Description

- 로컬 환경에서의 컴포즈 파일, 프로덕션 환경에서의 컴포즈 파일 두개 작성했습니다. 

### 1. 로컬

```
services:
  mysql:
    image: mysql:8.0
    container_name: mysql-chae-chae
    ports:
      - "3306:3306"
    env_file:
      - ./.env.mysql
    volumes:
      - mysql-data:/var/lib/mysql
    networks:
      - chae-chae-network
    restart: unless-stopped

  redis:
    image: redis:latest
    container_name: redis-chae-chae
    ports:
      - "6379:6379"
    volumes:
      - redis-data:/data
    networks:
      - chae-chae-network
    restart: unless-stopped

networks:
  chae-chae-network:
    driver: bridge

volumes:
  mysql-data:
  redis-data:
```

### 2. 프로덕션

```
services:
  backend:
    image: hyeonmin2/chae-chae-server:latest
    env_file:
      - ./.env.backend
    ports:
      - "8080:8080"
    depends_on:
      - mysql
      - redis
    networks:
      - chae-chae-network
    restart: unless-stopped
```
- 환경변수는 .env 파일이 있어야 동작 가능하게 만들었습니다.