### PR TITLE
[ FEAT ] 발주 생성 기능 구현

### DIFF
--- a/src/main/java/com/project/chaechaeserver/application/response/order/ResCreateOrderPostDTO.java
+++ b/src/main/java/com/project/chaechaeserver/application/response/order/ResCreateOrderPostDTO.java
@@ -14,9 +14,9 @@ public class ResCreateOrderPostDTO {
 
   private OrderInfo orderInfo;
 
-  public static ResCreateOrderPostDTO of(OrderInfo orderInfo) {
+  public static ResCreateOrderPostDTO from(OrderEntity orderEntity) {
     return ResCreateOrderPostDTO.builder()
-        .orderInfo(orderInfo)
+        .orderInfo(OrderInfo.from(orderEntity))
         .build();
   }
 

--- a/src/main/java/com/project/chaechaeserver/application/response/order/ResCreateOrderPostDTO.java
+++ b/src/main/java/com/project/chaechaeserver/application/response/order/ResCreateOrderPostDTO.java
@@ -28,9 +28,9 @@ public class ResCreateOrderPostDTO {
 
     private Long orderId;
     private Long productId;
-    private int quantity;
-    private int unitCost;
-    private int totalCost;
+    private Integer quantity;
+    private Integer unitCost;
+    private Integer totalCost;
     private String status;
 
     public static OrderInfo from(OrderEntity orderEntity) {

--- a/src/main/java/com/project/chaechaeserver/application/response/order/ResCreateOrderPostDTO.java
+++ b/src/main/java/com/project/chaechaeserver/application/response/order/ResCreateOrderPostDTO.java
@@ -1,0 +1,48 @@
+package com.project.chaechaeserver.application.response.order;
+
+import com.project.chaechaeserver.domain.model.order.OrderEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ResCreateOrderPostDTO {
+
+  private OrderInfo orderInfo;
+
+  public static ResCreateOrderPostDTO of(OrderInfo orderInfo) {
+    return ResCreateOrderPostDTO.builder()
+        .orderInfo(orderInfo)
+        .build();
+  }
+
+  @Getter
+  @AllArgsConstructor
+  @NoArgsConstructor
+  @Builder
+  public static class OrderInfo {
+
+    private Long orderId;
+    private Long productId;
+    private int quantity;
+    private int unitCost;
+    private int totalCost;
+    private String status;
+
+    public static OrderInfo from(OrderEntity orderEntity) {
+      return OrderInfo.builder()
+          .orderId(orderEntity.getId())
+          .productId(orderEntity.getProductId())
+          .quantity(orderEntity.getQuantity())
+          .unitCost(orderEntity.getUnitCost())
+          .totalCost(orderEntity.getTotalCost())
+          .status(orderEntity.getStatus().name())
+          .build();
+    }
+  }
+
+}

--- a/src/main/java/com/project/chaechaeserver/application/response/order/ResCreateOrderPostDTO.java
+++ b/src/main/java/com/project/chaechaeserver/application/response/order/ResCreateOrderPostDTO.java
@@ -12,11 +12,11 @@ import lombok.NoArgsConstructor;
 @Builder
 public class ResCreateOrderPostDTO {
 
-  private OrderInfo orderInfo;
+  private Order order;
 
   public static ResCreateOrderPostDTO from(OrderEntity orderEntity) {
     return ResCreateOrderPostDTO.builder()
-        .orderInfo(OrderInfo.from(orderEntity))
+        .order(Order.from(orderEntity))
         .build();
   }
 
@@ -24,7 +24,7 @@ public class ResCreateOrderPostDTO {
   @AllArgsConstructor
   @NoArgsConstructor
   @Builder
-  public static class OrderInfo {
+  public static class Order {
 
     private Long orderId;
     private Long productId;
@@ -33,8 +33,8 @@ public class ResCreateOrderPostDTO {
     private Integer totalCost;
     private String status;
 
-    public static OrderInfo from(OrderEntity orderEntity) {
-      return OrderInfo.builder()
+    public static Order from(OrderEntity orderEntity) {
+      return Order.builder()
           .orderId(orderEntity.getId())
           .productId(orderEntity.getProductId())
           .quantity(orderEntity.getQuantity())

--- a/src/main/java/com/project/chaechaeserver/application/service/order/OrderService.java
+++ b/src/main/java/com/project/chaechaeserver/application/service/order/OrderService.java
@@ -1,0 +1,10 @@
+package com.project.chaechaeserver.application.service.order;
+
+import com.project.chaechaeserver.application.response.order.ResCreateOrderPostDTO;
+import com.project.chaechaeserver.presentation.request.order.ReqCreateOrderDTO;
+
+public interface OrderService {
+
+  ResCreateOrderPostDTO createOrderInfo(ReqCreateOrderDTO request);
+
+}

--- a/src/main/java/com/project/chaechaeserver/application/service/order/OrderService.java
+++ b/src/main/java/com/project/chaechaeserver/application/service/order/OrderService.java
@@ -5,6 +5,6 @@ import com.project.chaechaeserver.presentation.request.order.ReqCreateOrderDTO;
 
 public interface OrderService {
 
-  ResCreateOrderPostDTO createOrderInfo(ReqCreateOrderDTO request);
+  ResCreateOrderPostDTO createOrderInfo(ReqCreateOrderDTO dto);
 
 }

--- a/src/main/java/com/project/chaechaeserver/application/service/order/OrderServiceImpl.java
+++ b/src/main/java/com/project/chaechaeserver/application/service/order/OrderServiceImpl.java
@@ -1,0 +1,45 @@
+package com.project.chaechaeserver.application.service.order;
+
+import com.project.chaechaeserver.application.response.order.ResCreateOrderPostDTO;
+import com.project.chaechaeserver.domain.model.order.OrderEntity;
+import com.project.chaechaeserver.domain.model.order.constraint.StatusType;
+import com.project.chaechaeserver.domain.repository.order.OrderRepository;
+import com.project.chaechaeserver.domain.service.order.OrderDomainService;
+import com.project.chaechaeserver.domain.service.products.ProductDomainService;
+import com.project.chaechaeserver.presentation.request.order.ReqCreateOrderDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OrderServiceImpl implements OrderService {
+
+  private final OrderRepository orderRepository;
+  private final OrderDomainService orderDomainService;
+  private final ProductDomainService productDomainService;
+
+  @Override
+  @Transactional
+  public ResCreateOrderPostDTO createOrderInfo(ReqCreateOrderDTO request) {
+    Long productId = request.getOrder().getProductId();
+    int quantity = request.getOrder().getQuantity();
+
+    if (quantity <= 0) {
+      throw new IllegalArgumentException("수량은 1개 이상이어야 합니다.");
+    }
+
+    orderDomainService.validateDuplicateOrder(productId);
+
+    int unitCost = productDomainService.getUnitPrice(productId);
+    StatusType status = StatusType.REQUESTED;
+
+    OrderEntity order = OrderEntity.createOrder(productId, quantity, unitCost, status);
+
+    OrderEntity savedOrder = orderRepository.save(order);
+
+    return ResCreateOrderPostDTO.of(
+        ResCreateOrderPostDTO.OrderInfo.from(savedOrder)
+    );
+  }
+}

--- a/src/main/java/com/project/chaechaeserver/application/service/order/OrderServiceImpl.java
+++ b/src/main/java/com/project/chaechaeserver/application/service/order/OrderServiceImpl.java
@@ -23,7 +23,7 @@ public class OrderServiceImpl implements OrderService {
   @Transactional
   public ResCreateOrderPostDTO createOrderInfo(ReqCreateOrderDTO request) {
     Long productId = request.getOrder().getProductId();
-    int quantity = request.getOrder().getQuantity();
+    Integer quantity = request.getOrder().getQuantity();
 
     if (quantity <= 0) {
       throw new IllegalArgumentException("수량은 1개 이상이어야 합니다.");
@@ -31,7 +31,7 @@ public class OrderServiceImpl implements OrderService {
 
     orderDomainService.validateDuplicateOrder(productId);
 
-    int unitCost = productDomainService.getUnitPrice(productId);
+    Integer unitCost = productDomainService.getUnitPrice(productId);
     StatusType status = StatusType.REQUESTED;
 
     OrderEntity order = OrderEntity.createOrder(productId, quantity, unitCost, status);

--- a/src/main/java/com/project/chaechaeserver/application/service/order/OrderServiceImpl.java
+++ b/src/main/java/com/project/chaechaeserver/application/service/order/OrderServiceImpl.java
@@ -34,8 +34,6 @@ public class OrderServiceImpl implements OrderService {
 
     OrderEntity savedOrder = orderRepository.save(order);
 
-    return ResCreateOrderPostDTO.of(
-        ResCreateOrderPostDTO.OrderInfo.from(savedOrder)
-    );
+    return ResCreateOrderPostDTO.from(savedOrder);
   }
 }

--- a/src/main/java/com/project/chaechaeserver/application/service/order/OrderServiceImpl.java
+++ b/src/main/java/com/project/chaechaeserver/application/service/order/OrderServiceImpl.java
@@ -25,10 +25,6 @@ public class OrderServiceImpl implements OrderService {
     Long productId = request.getOrder().getProductId();
     Integer quantity = request.getOrder().getQuantity();
 
-    if (quantity <= 0) {
-      throw new IllegalArgumentException("수량은 1개 이상이어야 합니다.");
-    }
-
     orderDomainService.validateDuplicateOrder(productId);
 
     Integer unitCost = productDomainService.getUnitPrice(productId);

--- a/src/main/java/com/project/chaechaeserver/application/service/order/OrderServiceImpl.java
+++ b/src/main/java/com/project/chaechaeserver/application/service/order/OrderServiceImpl.java
@@ -21,9 +21,9 @@ public class OrderServiceImpl implements OrderService {
 
   @Override
   @Transactional
-  public ResCreateOrderPostDTO createOrderInfo(ReqCreateOrderDTO request) {
-    Long productId = request.getOrder().getProductId();
-    Integer quantity = request.getOrder().getQuantity();
+  public ResCreateOrderPostDTO createOrderInfo(ReqCreateOrderDTO dto) {
+    Long productId = dto.getOrder().getProductId();
+    Integer quantity = dto.getOrder().getQuantity();
 
     orderDomainService.validateDuplicateOrder(productId);
 

--- a/src/main/java/com/project/chaechaeserver/domain/model/order/OrderEntity.java
+++ b/src/main/java/com/project/chaechaeserver/domain/model/order/OrderEntity.java
@@ -32,13 +32,13 @@ public class OrderEntity {
   private Long productId;
 
   @Column(name = "quantity", nullable = false)
-  private int quantity;
+  private Integer quantity;
 
   @Column(name = "unit_cost", nullable = false)
-  private int unitCost;
+  private Integer unitCost;
 
   @Column(name = "total_cost", nullable = false)
-  private int totalCost;
+  private Integer totalCost;
 
   @Column(name = "status", nullable = false)
   @Enumerated(EnumType.STRING)
@@ -57,7 +57,7 @@ public class OrderEntity {
 
 
   @Builder
-  public OrderEntity(Long productId, int quantity, int unitCost, int totalCost, StatusType status) {
+  public OrderEntity(Long productId, Integer quantity, Integer unitCost, Integer totalCost, StatusType status) {
     this.productId = productId;
     this.quantity = quantity;
     this.unitCost = unitCost;
@@ -65,7 +65,7 @@ public class OrderEntity {
     this.status = status;
   }
 
-  public static OrderEntity createOrder(Long productId, int quantity, int unitCost,
+  public static OrderEntity createOrder(Long productId, Integer quantity, Integer unitCost,
       StatusType status) {
     return OrderEntity.builder()
         .productId(productId)

--- a/src/main/java/com/project/chaechaeserver/domain/model/order/OrderEntity.java
+++ b/src/main/java/com/project/chaechaeserver/domain/model/order/OrderEntity.java
@@ -1,0 +1,79 @@
+package com.project.chaechaeserver.domain.model.order;
+
+import com.project.chaechaeserver.domain.model.order.constraint.StatusType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "orders")
+public class OrderEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "order_id")
+  private Long id;
+
+  @Column(name = "product_id", nullable = false)
+  private Long productId;
+
+  @Column(name = "quantity", nullable = false)
+  private int quantity;
+
+  @Column(name = "unit_cost", nullable = false)
+  private int unitCost;
+
+  @Column(name = "total_cost", nullable = false)
+  private int totalCost;
+
+  @Column(name = "status", nullable = false)
+  @Enumerated(EnumType.STRING)
+  private StatusType status;
+
+  @CreationTimestamp
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt;
+
+  @UpdateTimestamp
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt;
+
+  @Column(name = "deleted_at")
+  private LocalDateTime deletedAt;
+
+
+  @Builder
+  public OrderEntity(Long productId, int quantity, int unitCost, int totalCost, StatusType status) {
+    this.productId = productId;
+    this.quantity = quantity;
+    this.unitCost = unitCost;
+    this.totalCost = totalCost;
+    this.status = status;
+  }
+
+  public static OrderEntity createOrder(Long productId, int quantity, int unitCost,
+      StatusType status) {
+    return OrderEntity.builder()
+        .productId(productId)
+        .quantity(quantity)
+        .unitCost(unitCost)
+        .totalCost(quantity * unitCost)
+        .status(status)
+        .build();
+  }
+
+}

--- a/src/main/java/com/project/chaechaeserver/domain/model/order/constraint/StatusType.java
+++ b/src/main/java/com/project/chaechaeserver/domain/model/order/constraint/StatusType.java
@@ -1,0 +1,25 @@
+package com.project.chaechaeserver.domain.model.order.constraint;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum StatusType {
+
+  REQUESTED(Status.APPROVED, "요청"),
+  APPROVED(Status.APPROVED, "승인"),
+  COMPLETED(Status.COMPLETED, "완료"),
+  CANCELLED(Status.CANCELLED, "취소");
+
+  private final String status;
+  private final String displayName;
+
+  public static class Status {
+
+    public static final String REQUESTED = "STATUS_REQUESTED";
+    public static final String APPROVED = "STATUS_APPROVED";
+    public static final String COMPLETED = "STATUS_COMPLETED";
+    public static final String CANCELLED = "STATUS_CANCELLED";
+  }
+}

--- a/src/main/java/com/project/chaechaeserver/domain/repository/order/OrderRepository.java
+++ b/src/main/java/com/project/chaechaeserver/domain/repository/order/OrderRepository.java
@@ -1,0 +1,10 @@
+package com.project.chaechaeserver.domain.repository.order;
+
+import com.project.chaechaeserver.domain.model.order.OrderEntity;
+import com.project.chaechaeserver.domain.model.order.constraint.StatusType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<OrderEntity, Long> {
+
+  boolean existsByProductIdAndStatus(Long productId, StatusType statusType);
+}

--- a/src/main/java/com/project/chaechaeserver/domain/service/order/OrderDomainService.java
+++ b/src/main/java/com/project/chaechaeserver/domain/service/order/OrderDomainService.java
@@ -1,0 +1,5 @@
+package com.project.chaechaeserver.domain.service.order;
+
+public interface OrderDomainService {
+  void validateDuplicateOrder(Long productId);
+}

--- a/src/main/java/com/project/chaechaeserver/domain/service/order/OrderDomainServiceImpl.java
+++ b/src/main/java/com/project/chaechaeserver/domain/service/order/OrderDomainServiceImpl.java
@@ -1,0 +1,21 @@
+package com.project.chaechaeserver.domain.service.order;
+
+import com.project.chaechaeserver.domain.model.order.constraint.StatusType;
+import com.project.chaechaeserver.domain.repository.order.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class OrderDomainServiceImpl implements OrderDomainService {
+
+  private final OrderRepository orderRepository;
+
+  @Override
+  public void validateDuplicateOrder(Long productId) {
+    if (orderRepository.existsByProductIdAndStatus(productId, StatusType.REQUESTED)) {
+      throw new IllegalArgumentException("이미 발주 요청 중인 상품입니다.");
+    }
+  }
+
+}

--- a/src/main/java/com/project/chaechaeserver/domain/service/products/ProductDomainService.java
+++ b/src/main/java/com/project/chaechaeserver/domain/service/products/ProductDomainService.java
@@ -3,4 +3,7 @@ package com.project.chaechaeserver.domain.service.products;
 public interface ProductDomainService {
 
     void validateProductName(String name);
+
+    // 발주용 상품 가격 확인
+    int getUnitPrice(Long productId);
 }

--- a/src/main/java/com/project/chaechaeserver/domain/service/products/ProductDomainServiceImpl.java
+++ b/src/main/java/com/project/chaechaeserver/domain/service/products/ProductDomainServiceImpl.java
@@ -16,4 +16,12 @@ public class ProductDomainServiceImpl implements ProductDomainService {
             throw new IllegalArgumentException("이미 존재하는 상품명입니다: " + name);
         }
     }
+
+    // 발주용 상품 가격 확인
+    @Override
+    public int getUnitPrice(Long productId) {
+        return productsRepository.findById(productId)
+            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 상품입니다."))
+            .getPrice();
+    }
 }

--- a/src/main/java/com/project/chaechaeserver/presentation/controller/order/OrderController.java
+++ b/src/main/java/com/project/chaechaeserver/presentation/controller/order/OrderController.java
@@ -6,6 +6,7 @@ import com.project.chaechaeserver.application.global.dto.ResDTO;
 import com.project.chaechaeserver.application.response.order.ResCreateOrderPostDTO;
 import com.project.chaechaeserver.application.service.order.OrderService;
 import com.project.chaechaeserver.presentation.request.order.ReqCreateOrderDTO;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -25,7 +26,7 @@ public class OrderController {
   @PostMapping
   @Secured(ADMIN)
   public ResponseEntity<ResDTO<ResCreateOrderPostDTO>> createOrder(
-      @RequestBody ReqCreateOrderDTO request) {
+      @Valid @RequestBody ReqCreateOrderDTO request) {
 
     return new ResponseEntity<>(
         ResDTO.<ResCreateOrderPostDTO>builder()

--- a/src/main/java/com/project/chaechaeserver/presentation/controller/order/OrderController.java
+++ b/src/main/java/com/project/chaechaeserver/presentation/controller/order/OrderController.java
@@ -25,14 +25,13 @@ public class OrderController {
 
   @PostMapping
   @Secured(ADMIN)
-  public ResponseEntity<ResDTO<ResCreateOrderPostDTO>> createOrder(
-      @Valid @RequestBody ReqCreateOrderDTO request) {
+  public ResponseEntity<ResDTO<ResCreateOrderPostDTO>> createOrder(@Valid @RequestBody ReqCreateOrderDTO dto) {
 
     return new ResponseEntity<>(
         ResDTO.<ResCreateOrderPostDTO>builder()
             .code(HttpStatus.CREATED.value())
             .message("발주 생성 완료")
-            .data(orderService.createOrderInfo(request))
+            .data(orderService.createOrderInfo(dto))
             .build(),
         HttpStatus.CREATED
     );

--- a/src/main/java/com/project/chaechaeserver/presentation/controller/order/OrderController.java
+++ b/src/main/java/com/project/chaechaeserver/presentation/controller/order/OrderController.java
@@ -1,0 +1,39 @@
+package com.project.chaechaeserver.presentation.controller.order;
+
+import static com.project.chaechaeserver.domain.model.user.constraint.RoleType.Role.ADMIN;
+
+import com.project.chaechaeserver.application.global.dto.ResDTO;
+import com.project.chaechaeserver.application.response.order.ResCreateOrderPostDTO;
+import com.project.chaechaeserver.application.service.order.OrderService;
+import com.project.chaechaeserver.presentation.request.order.ReqCreateOrderDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/orders")
+public class OrderController {
+
+  private final OrderService orderService;
+
+  @PostMapping
+  @Secured(ADMIN)
+  public ResponseEntity<ResDTO<ResCreateOrderPostDTO>> createOrder(
+      @RequestBody ReqCreateOrderDTO request) {
+
+    return new ResponseEntity<>(
+        ResDTO.<ResCreateOrderPostDTO>builder()
+            .code(HttpStatus.CREATED.value())
+            .message("발주 생성 완료")
+            .data(orderService.createOrderInfo(request))
+            .build(),
+        HttpStatus.CREATED
+    );
+  }
+}

--- a/src/main/java/com/project/chaechaeserver/presentation/request/order/ReqCreateOrderDTO.java
+++ b/src/main/java/com/project/chaechaeserver/presentation/request/order/ReqCreateOrderDTO.java
@@ -25,7 +25,7 @@ public class ReqCreateOrderDTO {
   public static class Order {
 
     private Long productId;
-    private int quantity;
+    private Integer quantity;
 
   }
 }

--- a/src/main/java/com/project/chaechaeserver/presentation/request/order/ReqCreateOrderDTO.java
+++ b/src/main/java/com/project/chaechaeserver/presentation/request/order/ReqCreateOrderDTO.java
@@ -1,6 +1,7 @@
 package com.project.chaechaeserver.presentation.request.order;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,7 +15,7 @@ import lombok.NoArgsConstructor;
 public class ReqCreateOrderDTO {
 
   @Valid
-  @NotNull
+  @NotNull(message = "발주를 위한 정보를 입력해주세요.")
   private Order order;
 
 
@@ -25,6 +26,8 @@ public class ReqCreateOrderDTO {
   public static class Order {
 
     private Long productId;
+
+    @Min(value = 1, message = "수량은 1개 이상이어야 합니다.")
     private Integer quantity;
 
   }

--- a/src/main/java/com/project/chaechaeserver/presentation/request/order/ReqCreateOrderDTO.java
+++ b/src/main/java/com/project/chaechaeserver/presentation/request/order/ReqCreateOrderDTO.java
@@ -1,0 +1,31 @@
+package com.project.chaechaeserver.presentation.request.order;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ReqCreateOrderDTO {
+
+  @Valid
+  @NotNull
+  private Order order;
+
+
+  @Getter
+  @Builder
+  @AllArgsConstructor
+  @NoArgsConstructor
+  public static class Order {
+
+    private Long productId;
+    private int quantity;
+
+  }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #20 

## 📝 Description

- 발주 생성 기능 구현

### 발주 요청 예시

```
{
  "order": {
    "productId": 1,
    "quantity": 5
  }
}
```

### 응답 결과
<img width="263" alt="스크린샷 2025-07-06 오후 5 24 48" src="https://github.com/user-attachments/assets/24555b82-7bb0-4375-a719-2087e83aa95d" />

## 💬 To Reivewers

- 현재는 상품 도메인 서비스(ProductDomainService)를 직접 호출하여 상품 존재 여부 및 가격 조회를 확인하고 있습니다.
   추후 발주 도메인에서 이벤트 기반으로 처리하도록 구조 변경할 예정입니다.
