### PR TITLE
[ REFACTOR ] 유저 서비스 레이어 추상화 및 Redis 로직 분리, 정적 팩토리 메소드 리팩토링

### DIFF
--- a/src/main/java/com/project/chaechaeserver/application/response/user/ResInternalUserPostSignupDTO.java
+++ b/src/main/java/com/project/chaechaeserver/application/response/user/ResInternalUserPostSignupDTO.java
@@ -14,7 +14,7 @@ public class ResInternalUserPostSignupDTO {
 
     private InternalUser internalUser;
 
-    public static ResInternalUserPostSignupDTO of(InternalUserEntity internalUserEntity) {
+    public static ResInternalUserPostSignupDTO from(InternalUserEntity internalUserEntity) {
         return ResInternalUserPostSignupDTO.builder()
                 .internalUser(InternalUser.from(internalUserEntity))
                 .build();

--- a/src/main/java/com/project/chaechaeserver/application/service/redis/RedisRefreshTokenService.java
+++ b/src/main/java/com/project/chaechaeserver/application/service/redis/RedisRefreshTokenService.java
@@ -1,4 +1,4 @@
-package com.project.chaechaeserver.application.service.user;
+package com.project.chaechaeserver.application.service.redis;
 
 
 public interface RedisRefreshTokenService {

--- a/src/main/java/com/project/chaechaeserver/application/service/user/InternalUserService.java
+++ b/src/main/java/com/project/chaechaeserver/application/service/user/InternalUserService.java
@@ -1,44 +1,9 @@
 package com.project.chaechaeserver.application.service.user;
 
 import com.project.chaechaeserver.application.response.user.ResInternalUserPostSignupDTO;
-import com.project.chaechaeserver.domain.model.user.InternalUserEntity;
-import com.project.chaechaeserver.domain.model.user.constraint.PositionType;
-import com.project.chaechaeserver.domain.model.user.constraint.RoleType;
-import com.project.chaechaeserver.domain.repository.user.InternalUserRepository;
 import com.project.chaechaeserver.presentation.request.user.ReqInternalUserPostSignupDTO;
-import jakarta.transaction.Transactional;
-import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.stereotype.Service;
 
-@Service
-@RequiredArgsConstructor
-public class InternalUserService {
+public interface InternalUserService {
 
-    private final InternalUserRepository internalUserRepository;
-    private final PasswordEncoder passwordEncoder;
-
-    @Transactional
-    public ResInternalUserPostSignupDTO signup(ReqInternalUserPostSignupDTO dto) {
-
-        // -- 이메일 중복확인 -- //
-        internalUserRepository.findByEmailDeletedAtIsNull(dto.getInternalUser().getEmail())
-                .ifPresent(internalUser -> {
-                    throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
-                });
-
-        // -- 회원 생성 -- //
-        InternalUserEntity savingForInternalUserEntity = InternalUserEntity.createInternalUser(
-                dto.getInternalUser().getEmail(),
-                passwordEncoder.encode(dto.getInternalUser().getPassword()),
-                dto.getInternalUser().getRealName(),
-                PositionType.valueOf(dto.getInternalUser().getPosition()),
-                RoleType.valueOf(dto.getInternalUser().getRole())
-        );
-
-        // -- 회원 저장 -- //
-        internalUserRepository.save(savingForInternalUserEntity);
-
-        return ResInternalUserPostSignupDTO.of(savingForInternalUserEntity);
-    }
+    ResInternalUserPostSignupDTO signup(ReqInternalUserPostSignupDTO dto);
 }

--- a/src/main/java/com/project/chaechaeserver/application/service/user/InternalUserServiceImpl.java
+++ b/src/main/java/com/project/chaechaeserver/application/service/user/InternalUserServiceImpl.java
@@ -40,6 +40,6 @@ public class InternalUserServiceImpl implements InternalUserService {
         // -- 회원 저장 -- //
         internalUserRepository.save(savingForInternalUserEntity);
 
-        return ResInternalUserPostSignupDTO.of(savingForInternalUserEntity);
+        return ResInternalUserPostSignupDTO.from(savingForInternalUserEntity);
     }
 }

--- a/src/main/java/com/project/chaechaeserver/application/service/user/InternalUserServiceImpl.java
+++ b/src/main/java/com/project/chaechaeserver/application/service/user/InternalUserServiceImpl.java
@@ -1,0 +1,45 @@
+package com.project.chaechaeserver.application.service.user;
+
+import com.project.chaechaeserver.application.response.user.ResInternalUserPostSignupDTO;
+import com.project.chaechaeserver.domain.model.user.InternalUserEntity;
+import com.project.chaechaeserver.domain.model.user.constraint.PositionType;
+import com.project.chaechaeserver.domain.model.user.constraint.RoleType;
+import com.project.chaechaeserver.domain.repository.user.InternalUserRepository;
+import com.project.chaechaeserver.presentation.request.user.ReqInternalUserPostSignupDTO;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class InternalUserServiceImpl implements InternalUserService {
+
+    private final InternalUserRepository internalUserRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    @Transactional
+    public ResInternalUserPostSignupDTO signup(ReqInternalUserPostSignupDTO dto) {
+
+        // -- 이메일 중복확인 -- //
+        internalUserRepository.findByEmailDeletedAtIsNull(dto.getInternalUser().getEmail())
+                .ifPresent(internalUser -> {
+                    throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
+                });
+
+        // -- 회원 생성 -- //
+        InternalUserEntity savingForInternalUserEntity = InternalUserEntity.createInternalUser(
+                dto.getInternalUser().getEmail(),
+                passwordEncoder.encode(dto.getInternalUser().getPassword()),
+                dto.getInternalUser().getRealName(),
+                PositionType.valueOf(dto.getInternalUser().getPosition()),
+                RoleType.valueOf(dto.getInternalUser().getRole())
+        );
+
+        // -- 회원 저장 -- //
+        internalUserRepository.save(savingForInternalUserEntity);
+
+        return ResInternalUserPostSignupDTO.of(savingForInternalUserEntity);
+    }
+}

--- a/src/main/java/com/project/chaechaeserver/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/project/chaechaeserver/infrastructure/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 package com.project.chaechaeserver.infrastructure.config;
 
-import com.project.chaechaeserver.application.service.user.RedisRefreshTokenService;
+import com.project.chaechaeserver.application.service.redis.RedisRefreshTokenService;
 import com.project.chaechaeserver.infrastructure.security.CustomUserDetailsService;
 import com.project.chaechaeserver.infrastructure.util.JwtUtil;
 import com.project.chaechaeserver.presentation.filter.JwtAuthenticationFilter;

--- a/src/main/java/com/project/chaechaeserver/infrastructure/service/redis/RedisRefreshTokenServiceImpl.java
+++ b/src/main/java/com/project/chaechaeserver/infrastructure/service/redis/RedisRefreshTokenServiceImpl.java
@@ -1,6 +1,6 @@
 package com.project.chaechaeserver.infrastructure.service.redis;
 
-import com.project.chaechaeserver.application.service.user.RedisRefreshTokenService;
+import com.project.chaechaeserver.application.service.redis.RedisRefreshTokenService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/project/chaechaeserver/presentation/controller/user/InternalUserController.java
+++ b/src/main/java/com/project/chaechaeserver/presentation/controller/user/InternalUserController.java
@@ -2,8 +2,8 @@ package com.project.chaechaeserver.presentation.controller.user;
 
 import com.project.chaechaeserver.application.global.dto.ResDTO;
 import com.project.chaechaeserver.application.service.user.InternalUserService;
+import com.project.chaechaeserver.application.service.user.InternalUserServiceImpl;
 import com.project.chaechaeserver.application.response.user.ResInternalUserPostSignupDTO;
-import com.project.chaechaeserver.domain.model.user.constraint.RoleType;
 import com.project.chaechaeserver.presentation.request.user.ReqInternalUserPostSignupDTO;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/project/chaechaeserver/presentation/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/project/chaechaeserver/presentation/filter/JwtAuthenticationFilter.java
@@ -1,7 +1,7 @@
 package com.project.chaechaeserver.presentation.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.project.chaechaeserver.application.service.user.RedisRefreshTokenService;
+import com.project.chaechaeserver.application.service.redis.RedisRefreshTokenService;
 import com.project.chaechaeserver.domain.model.user.constraint.RoleType;
 import com.project.chaechaeserver.infrastructure.security.CustomUserDetails;
 import com.project.chaechaeserver.infrastructure.util.JwtUtil;

--- a/src/main/java/com/project/chaechaeserver/presentation/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/project/chaechaeserver/presentation/filter/JwtAuthorizationFilter.java
@@ -1,6 +1,6 @@
 package com.project.chaechaeserver.presentation.filter;
 
-import com.project.chaechaeserver.application.service.user.RedisRefreshTokenService;
+import com.project.chaechaeserver.application.service.redis.RedisRefreshTokenService;
 import com.project.chaechaeserver.domain.model.user.constraint.RoleType;
 import com.project.chaechaeserver.infrastructure.security.CustomUserDetailsService;
 import com.project.chaechaeserver.infrastructure.util.JwtUtil;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #36 

## 📝 Description

- `Redis` 관련 서비스 레이러를 `redis` 패키지 하위로 이동시켰습니다.
- `internalUserService` 레이어를 추상화 하여 계층간 분리를 도모했습니다.
- 정적  팩토리 메소드를 의도에 맞게 네이밍을 반영하였습니다.
