### PR TITLE
[ DOCS ] 판매기록 도메인 Swagger 문서화 및 응답 구조 Wrapping 적용

### DIFF
--- a/src/main/java/com/project/chaechaeserver/application/response/sales/ResSalesGetByIdDTO.java
+++ b/src/main/java/com/project/chaechaeserver/application/response/sales/ResSalesGetByIdDTO.java
@@ -1,6 +1,7 @@
 package com.project.chaechaeserver.application.response.sales;
 
 import com.project.chaechaeserver.domain.model.sales.SalesEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,12 +29,24 @@ public class ResSalesGetByIdDTO {
     @AllArgsConstructor
     public static class Sales {
 
+        @Schema(example = "101")
         private Long salesId;
+
+        @Schema(example = "53")
         private Long productId;
+
+        @Schema(example = "유기농 사과 5kg")
         private String productName;
+
+        @Schema(example = "3")
         private int quantity;
+
+        @Schema(example = "15000")
         private int price;
+
+        @Schema(example = "45000")
         private int totalPrice;
+
         private LocalDateTime createdAt;
 
         public static Sales from(SalesEntity salesEntity) {

--- a/src/main/java/com/project/chaechaeserver/application/response/sales/ResSalesSearchDTO.java
+++ b/src/main/java/com/project/chaechaeserver/application/response/sales/ResSalesSearchDTO.java
@@ -1,6 +1,7 @@
 package com.project.chaechaeserver.application.response.sales;
 
 import com.project.chaechaeserver.domain.model.sales.SalesEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -46,12 +47,24 @@ public class ResSalesSearchDTO {
         @AllArgsConstructor
         public static class Sales {
 
+            @Schema(example = "101")
             private Long salesId;
+
+            @Schema(example = "53")
             private Long productId;
+
+            @Schema(example = "유기농 사과 5kg")
             private String productName;
+
+            @Schema(example = "3")
             private int quantity;
+
+            @Schema(example = "15000")
             private int price;
+
+            @Schema(example = "45000")
             private int totalPrice;
+
             private LocalDateTime createdAt;
 
             public static List<Sales> from(List<SalesEntity> salesEntityList) {
@@ -83,9 +96,16 @@ public class ResSalesSearchDTO {
         @AllArgsConstructor
         public static class PageDetails {
 
+            @Schema(example = "10")
             private int size;
+
+            @Schema(example = "0")
             private int number;
+
+            @Schema(example = "25")
             private long totalElements;
+
+            @Schema(example = "3")
             private int totalPages;
 
             public static PageDetails from(Page<SalesEntity> salesEntityPage) {

--- a/src/main/java/com/project/chaechaeserver/infrastructure/config/SwaggerConfig.java
+++ b/src/main/java/com/project/chaechaeserver/infrastructure/config/SwaggerConfig.java
@@ -1,9 +1,13 @@
 package com.project.chaechaeserver.infrastructure.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -30,4 +34,33 @@ public class SwaggerConfig {
                 .addSecurityItem(securityRequirement)
                 .schemaRequirement("BearerAuth", securityScheme);
     }
+
+    @Bean
+    public OperationCustomizer operationCustomizer() {
+        return (operation, handlerMethod) -> {
+            this.addResponseBodyWrapperSchemaExample(operation);
+            return operation;
+        };
+    }
+
+    private void addResponseBodyWrapperSchemaExample(Operation operation) {
+        final Content content = operation.getResponses().get("200").getContent();
+        if (content != null) {
+            content.forEach((mediaTypeKey, mediaType) -> {
+                Schema<?> originalSchema = mediaType.getSchema();
+                Schema<?> wrappedSchema = wrapSchema(originalSchema);
+                mediaType.setSchema(wrappedSchema);
+            });
+        }
+    }
+
+    private Schema<?> wrapSchema(Schema<?> originalSchema) {
+        final Schema<?> wrapperSchema = new Schema<>();
+        wrapperSchema.addProperty("code", new Schema<>().type("integer").example(200));
+        wrapperSchema.addProperty("message", new Schema<>().type("string").example("요청에 성공하였습니다"));
+        wrapperSchema.addProperty("data", originalSchema);
+
+        return wrapperSchema;
+    }
+
 }

--- a/src/main/java/com/project/chaechaeserver/infrastructure/sales/docs/SalesControllerSwagger.java
+++ b/src/main/java/com/project/chaechaeserver/infrastructure/sales/docs/SalesControllerSwagger.java
@@ -1,0 +1,50 @@
+package com.project.chaechaeserver.infrastructure.sales.docs;
+
+import com.project.chaechaeserver.application.global.dto.ResDTO;
+import com.project.chaechaeserver.application.response.sales.ResSalesGetByIdDTO;
+import com.project.chaechaeserver.application.response.sales.ResSalesSearchDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Tag(name = "Sales", description = "판매기록 관련 API를 제공합니다.")
+@RequestMapping("/api/sales")
+public interface SalesControllerSwagger {
+
+    @Operation(summary = "판매기록 상세조회", description = "판매기록을 상세조회하는 API 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "상세조회 성공", content = @Content(schema = @Schema(implementation = ResSalesGetByIdDTO.class))),
+            @ApiResponse(responseCode = "400", description = "상세조회 실패.", content = @Content(schema = @Schema(implementation = ResSalesGetByIdDTO.class)))
+    })
+    @GetMapping("/{salesId}")
+    ResponseEntity<ResDTO<ResSalesGetByIdDTO>> getSalesBySalesId(@PathVariable Long salesId);
+
+    @Operation(summary = "판매기록 검색", description = "판매기록을 검색하는 API 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "검색 성공", content = @Content(schema = @Schema(implementation = ResSalesSearchDTO.class))),
+            @ApiResponse(responseCode = "400", description = "검색 실패.", content = @Content(schema = @Schema(implementation = ResSalesSearchDTO.class)))
+    })
+    @GetMapping
+    ResponseEntity<ResDTO<ResSalesSearchDTO>> searchSalesByCondition(@RequestParam(required = false) Boolean deleted,
+                                                                            @RequestParam(required = false) String productName,
+                                                                            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+                                                                            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+                                                                            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate exactDate,
+                                                                            @RequestParam(required = false) List<String> sort,
+                                                                            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable);
+}

--- a/src/main/java/com/project/chaechaeserver/presentation/controller/sales/SalesController.java
+++ b/src/main/java/com/project/chaechaeserver/presentation/controller/sales/SalesController.java
@@ -4,6 +4,7 @@ import com.project.chaechaeserver.application.global.dto.ResDTO;
 import com.project.chaechaeserver.application.response.sales.ResSalesGetByIdDTO;
 import com.project.chaechaeserver.application.response.sales.ResSalesSearchDTO;
 import com.project.chaechaeserver.application.service.sales.SalesService;
+import com.project.chaechaeserver.infrastructure.sales.docs.SalesControllerSwagger;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -19,7 +20,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/sales")
-public class SalesController {
+public class SalesController implements SalesControllerSwagger {
 
     private final SalesService salesService;
 
@@ -43,7 +44,7 @@ public class SalesController {
                                                                             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
                                                                             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate exactDate,
                                                                             @RequestParam(required = false) List<String> sort,
-                                                                            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+                                                                            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         return new ResponseEntity<>(
                 ResDTO.<ResSalesSearchDTO>builder()
                         .code(HttpStatus.OK.value())


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #42 

## 📝 Description

- 판매기록 단건 조회, 목록 조회 API에 Swagger 응답 문서 작성
- OperationCustomizer를 활용해 Swagger 200 응답 스키마를 자동으로 공통 구조(`code`, `message`, `data`)로 래핑
- Swagger UI의 Example Value 에서도 응답 포맷이 일관되도록 문서화
