### PR TITLE
[ REFACTOR ] 상품 정보 참조 방식 및 필드 리팩토링

### DIFF
--- a/src/main/java/com/project/chaechaeserver/application/response/order/ResCreateOrderPostDTO.java
+++ b/src/main/java/com/project/chaechaeserver/application/response/order/ResCreateOrderPostDTO.java
@@ -38,6 +38,7 @@ public class ResCreateOrderPostDTO {
     public static Order from(OrderEntity orderEntity) {
       return Order.builder()
           .orderId(orderEntity.getId())
+          .productId(orderEntity.getProduct().getId())
           .productName(orderEntity.getProduct().getName())
           .productCategory(orderEntity.getProduct().getCategory())
           .quantity(orderEntity.getQuantity())

--- a/src/main/java/com/project/chaechaeserver/application/response/order/ResCreateOrderPostDTO.java
+++ b/src/main/java/com/project/chaechaeserver/application/response/order/ResCreateOrderPostDTO.java
@@ -28,6 +28,8 @@ public class ResCreateOrderPostDTO {
 
     private Long orderId;
     private Long productId;
+    private String productName;
+    private String productCategory;
     private Integer quantity;
     private Integer unitCost;
     private Integer totalCost;
@@ -36,7 +38,8 @@ public class ResCreateOrderPostDTO {
     public static Order from(OrderEntity orderEntity) {
       return Order.builder()
           .orderId(orderEntity.getId())
-          .productId(orderEntity.getProductId())
+          .productName(orderEntity.getProduct().getName())
+          .productCategory(orderEntity.getProduct().getCategory())
           .quantity(orderEntity.getQuantity())
           .unitCost(orderEntity.getUnitCost())
           .totalCost(orderEntity.getTotalCost())

--- a/src/main/java/com/project/chaechaeserver/application/response/order/ResCreateOrderPostDTO.java
+++ b/src/main/java/com/project/chaechaeserver/application/response/order/ResCreateOrderPostDTO.java
@@ -1,6 +1,7 @@
 package com.project.chaechaeserver.application.response.order;
 
 import com.project.chaechaeserver.domain.model.order.OrderEntity;
+import com.project.chaechaeserver.domain.model.order.ProductInfo;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -30,19 +31,20 @@ public class ResCreateOrderPostDTO {
     private Long productId;
     private String productName;
     private String productCategory;
+    private Integer productPrice;
     private Integer quantity;
-    private Integer unitCost;
     private Integer totalCost;
     private String status;
 
     public static Order from(OrderEntity orderEntity) {
+      ProductInfo productInfo = orderEntity.getProductInfo();
       return Order.builder()
           .orderId(orderEntity.getId())
-          .productId(orderEntity.getProduct().getId())
-          .productName(orderEntity.getProduct().getName())
-          .productCategory(orderEntity.getProduct().getCategory())
+          .productId(productInfo.getProductId())
+          .productName(productInfo.getProductName())
+          .productCategory(productInfo.getProductCategory())
+          .productPrice(productInfo.getProductPrice())
           .quantity(orderEntity.getQuantity())
-          .unitCost(orderEntity.getUnitCost())
           .totalCost(orderEntity.getTotalCost())
           .status(orderEntity.getStatus().name())
           .build();

--- a/src/main/java/com/project/chaechaeserver/application/service/order/OrderServiceImpl.java
+++ b/src/main/java/com/project/chaechaeserver/application/service/order/OrderServiceImpl.java
@@ -3,6 +3,7 @@ package com.project.chaechaeserver.application.service.order;
 import com.project.chaechaeserver.application.response.order.ResCreateOrderPostDTO;
 import com.project.chaechaeserver.domain.model.order.OrderEntity;
 import com.project.chaechaeserver.domain.model.order.constraint.StatusType;
+import com.project.chaechaeserver.domain.model.products.ProductEntity;
 import com.project.chaechaeserver.domain.repository.order.OrderRepository;
 import com.project.chaechaeserver.domain.service.order.OrderDomainService;
 import com.project.chaechaeserver.domain.service.products.ProductDomainService;
@@ -27,10 +28,11 @@ public class OrderServiceImpl implements OrderService {
 
     orderDomainService.validateDuplicateOrder(productId);
 
-    Integer unitCost = productDomainService.getUnitPrice(productId);
-    StatusType status = StatusType.REQUESTED;
+    StatusType status = StatusType.APPROVED;
 
-    OrderEntity order = OrderEntity.createOrder(productId, quantity, unitCost, status);
+    ProductEntity product = productDomainService.findProductById(productId);
+
+    OrderEntity order = OrderEntity.createOrder(product, quantity, status);
 
     OrderEntity savedOrder = orderRepository.save(order);
 

--- a/src/main/java/com/project/chaechaeserver/application/service/order/OrderServiceImpl.java
+++ b/src/main/java/com/project/chaechaeserver/application/service/order/OrderServiceImpl.java
@@ -2,6 +2,7 @@ package com.project.chaechaeserver.application.service.order;
 
 import com.project.chaechaeserver.application.response.order.ResCreateOrderPostDTO;
 import com.project.chaechaeserver.domain.model.order.OrderEntity;
+import com.project.chaechaeserver.domain.model.order.ProductInfo;
 import com.project.chaechaeserver.domain.model.order.constraint.StatusType;
 import com.project.chaechaeserver.domain.model.products.ProductEntity;
 import com.project.chaechaeserver.domain.repository.order.OrderRepository;
@@ -28,7 +29,7 @@ public class OrderServiceImpl implements OrderService {
 
     orderDomainService.validateDuplicateOrder(productId);
 
-    StatusType status = StatusType.APPROVED;
+    StatusType status = StatusType.DEFAULT;
 
     ProductEntity product = productDomainService.findProductById(productId);
 

--- a/src/main/java/com/project/chaechaeserver/application/service/order/OrderServiceImpl.java
+++ b/src/main/java/com/project/chaechaeserver/application/service/order/OrderServiceImpl.java
@@ -33,7 +33,14 @@ public class OrderServiceImpl implements OrderService {
 
     ProductEntity product = productDomainService.findProductById(productId);
 
-    OrderEntity order = OrderEntity.createOrder(product, quantity, status);
+    ProductInfo productInfo = new ProductInfo(
+        product.getId(),
+        product.getName(),
+        product.getCategory(),
+        product.getPrice()
+    );
+
+    OrderEntity order = OrderEntity.createOrder(productInfo, quantity, status);
 
     OrderEntity savedOrder = orderRepository.save(order);
 

--- a/src/main/java/com/project/chaechaeserver/domain/model/order/OrderEntity.java
+++ b/src/main/java/com/project/chaechaeserver/domain/model/order/OrderEntity.java
@@ -1,13 +1,18 @@
 package com.project.chaechaeserver.domain.model.order;
 
 import com.project.chaechaeserver.domain.model.order.constraint.StatusType;
+import com.project.chaechaeserver.domain.model.products.ProductEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -16,10 +21,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
 @Table(name = "orders")
 public class OrderEntity {
 
@@ -28,14 +37,15 @@ public class OrderEntity {
   @Column(name = "order_id")
   private Long id;
 
-  @Column(name = "product_id", nullable = false)
-  private Long productId;
-
-  @Column(name = "quantity", nullable = false)
-  private Integer quantity;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "product_id")
+  private ProductEntity product;
 
   @Column(name = "unit_cost", nullable = false)
   private Integer unitCost;
+
+  @Column(name = "quantity", nullable = false)
+  private Integer quantity;
 
   @Column(name = "total_cost", nullable = false)
   private Integer totalCost;
@@ -48,30 +58,42 @@ public class OrderEntity {
   @Column(name = "created_at", nullable = false)
   private LocalDateTime createdAt;
 
+  @CreatedBy
+  @Column(name = "created_by",updatable = false)
+  private String createdBy;
+
   @UpdateTimestamp
   @Column(name = "updated_at", nullable = false)
   private LocalDateTime updatedAt;
 
+  @LastModifiedBy
+  @Column(name = "updated_by", nullable = false)
+  private String updatedBy;
+
   @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
 
+  @Column(name = "deleted_by")
+  private String deletedBy;
+
 
   @Builder
-  public OrderEntity(Long productId, Integer quantity, Integer unitCost, Integer totalCost, StatusType status) {
-    this.productId = productId;
-    this.quantity = quantity;
+  public OrderEntity(ProductEntity product, Integer unitCost, Integer quantity, Integer totalCost, StatusType status) {
+    this.product = product;
     this.unitCost = unitCost;
+    this.quantity = quantity;
     this.totalCost = totalCost;
     this.status = status;
   }
 
-  public static OrderEntity createOrder(Long productId, Integer quantity, Integer unitCost,
-      StatusType status) {
+  public static OrderEntity createOrder(ProductEntity product, Integer quantity, StatusType status) {
+    int unitCost = product.getPrice();
+    int totalCost = unitCost * quantity;
     return OrderEntity.builder()
-        .productId(productId)
-        .quantity(quantity)
+        .product(product)
         .unitCost(unitCost)
-        .totalCost(quantity * unitCost)
+        .quantity(quantity)
+        .totalCost(totalCost)
         .status(status)
         .build();
   }

--- a/src/main/java/com/project/chaechaeserver/domain/model/order/OrderEntity.java
+++ b/src/main/java/com/project/chaechaeserver/domain/model/order/OrderEntity.java
@@ -1,18 +1,17 @@
 package com.project.chaechaeserver.domain.model.order;
 
 import com.project.chaechaeserver.domain.model.order.constraint.StatusType;
-import com.project.chaechaeserver.domain.model.products.ProductEntity;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -37,12 +36,14 @@ public class OrderEntity {
   @Column(name = "order_id")
   private Long id;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "product_id")
-  private ProductEntity product;
-
-  @Column(name = "unit_cost", nullable = false)
-  private Integer unitCost;
+  @Embedded
+  @AttributeOverrides({
+      @AttributeOverride(name = "productId", column = @Column(name = "product_id")),
+      @AttributeOverride(name = "productName", column = @Column(name = "product_name")),
+      @AttributeOverride(name = "productCategory", column = @Column(name = "product_category")),
+      @AttributeOverride(name = "productPrice", column = @Column(name = "product_price"))
+  })
+  private ProductInfo productInfo;
 
   @Column(name = "quantity", nullable = false)
   private Integer quantity;
@@ -59,7 +60,7 @@ public class OrderEntity {
   private LocalDateTime createdAt;
 
   @CreatedBy
-  @Column(name = "created_by",updatable = false)
+  @Column(name = "created_by", updatable = false)
   private String createdBy;
 
   @UpdateTimestamp
@@ -78,20 +79,17 @@ public class OrderEntity {
 
 
   @Builder
-  public OrderEntity(ProductEntity product, Integer unitCost, Integer quantity, Integer totalCost, StatusType status) {
-    this.product = product;
-    this.unitCost = unitCost;
+  public OrderEntity(ProductInfo productInfo, Integer quantity, Integer totalCost, StatusType status) {
+    this.productInfo = productInfo;
     this.quantity = quantity;
     this.totalCost = totalCost;
     this.status = status;
   }
 
-  public static OrderEntity createOrder(ProductEntity product, Integer quantity, StatusType status) {
-    int unitCost = product.getPrice();
-    int totalCost = unitCost * quantity;
+  public static OrderEntity createOrder(ProductInfo productInfo, Integer quantity, StatusType status) {
+    int totalCost = productInfo.getProductPrice() * quantity;
     return OrderEntity.builder()
-        .product(product)
-        .unitCost(unitCost)
+        .productInfo(productInfo)
         .quantity(quantity)
         .totalCost(totalCost)
         .status(status)

--- a/src/main/java/com/project/chaechaeserver/domain/model/order/ProductInfo.java
+++ b/src/main/java/com/project/chaechaeserver/domain/model/order/ProductInfo.java
@@ -1,0 +1,27 @@
+package com.project.chaechaeserver.domain.model.order;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode
+public class ProductInfo {
+
+  private Long productId;
+  private String productName;
+  private String productCategory;
+  private Integer productPrice;
+
+  public ProductInfo(Long productId, String productName, String productCategory, Integer productPrice) {
+    this.productId = productId;
+    this.productName = productName;
+    this.productCategory = productCategory;
+    this.productPrice = productPrice;
+  }
+
+}

--- a/src/main/java/com/project/chaechaeserver/domain/model/order/constraint/StatusType.java
+++ b/src/main/java/com/project/chaechaeserver/domain/model/order/constraint/StatusType.java
@@ -7,7 +7,6 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum StatusType {
 
-  REQUESTED(Status.APPROVED, "요청"),
   APPROVED(Status.APPROVED, "승인"),
   COMPLETED(Status.COMPLETED, "완료"),
   CANCELLED(Status.CANCELLED, "취소");
@@ -17,7 +16,6 @@ public enum StatusType {
 
   public static class Status {
 
-    public static final String REQUESTED = "STATUS_REQUESTED";
     public static final String APPROVED = "STATUS_APPROVED";
     public static final String COMPLETED = "STATUS_COMPLETED";
     public static final String CANCELLED = "STATUS_CANCELLED";

--- a/src/main/java/com/project/chaechaeserver/domain/model/order/constraint/StatusType.java
+++ b/src/main/java/com/project/chaechaeserver/domain/model/order/constraint/StatusType.java
@@ -20,4 +20,6 @@ public enum StatusType {
     public static final String COMPLETED = "STATUS_COMPLETED";
     public static final String CANCELLED = "STATUS_CANCELLED";
   }
+
+  public static final StatusType DEFAULT = APPROVED;
 }

--- a/src/main/java/com/project/chaechaeserver/domain/repository/order/OrderRepository.java
+++ b/src/main/java/com/project/chaechaeserver/domain/repository/order/OrderRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderRepository extends JpaRepository<OrderEntity, Long> {
 
-  boolean existsByProductIdAndStatus(Long productId, StatusType statusType);
+  boolean existsByProductInfo_ProductIdAndStatus(Long productId, StatusType status);
 }

--- a/src/main/java/com/project/chaechaeserver/domain/service/order/OrderDomainServiceImpl.java
+++ b/src/main/java/com/project/chaechaeserver/domain/service/order/OrderDomainServiceImpl.java
@@ -13,8 +13,8 @@ public class OrderDomainServiceImpl implements OrderDomainService {
 
   @Override
   public void validateDuplicateOrder(Long productId) {
-    if (orderRepository.existsByProductIdAndStatus(productId, StatusType.REQUESTED)) {
-      throw new IllegalArgumentException("이미 발주 요청 중인 상품입니다.");
+    if (orderRepository.existsByProductIdAndStatus(productId, StatusType.APPROVED)) {
+      throw new IllegalArgumentException("이미 발주 중인 상품입니다.");
     }
   }
 

--- a/src/main/java/com/project/chaechaeserver/domain/service/order/OrderDomainServiceImpl.java
+++ b/src/main/java/com/project/chaechaeserver/domain/service/order/OrderDomainServiceImpl.java
@@ -13,7 +13,7 @@ public class OrderDomainServiceImpl implements OrderDomainService {
 
   @Override
   public void validateDuplicateOrder(Long productId) {
-    if (orderRepository.existsByProductIdAndStatus(productId, StatusType.APPROVED)) {
+    if (orderRepository.existsByProductInfo_ProductIdAndStatus(productId, StatusType.APPROVED)) {
       throw new IllegalArgumentException("이미 발주 중인 상품입니다.");
     }
   }

--- a/src/main/java/com/project/chaechaeserver/domain/service/products/ProductDomainService.java
+++ b/src/main/java/com/project/chaechaeserver/domain/service/products/ProductDomainService.java
@@ -1,9 +1,11 @@
 package com.project.chaechaeserver.domain.service.products;
 
+import com.project.chaechaeserver.domain.model.products.ProductEntity;
+
 public interface ProductDomainService {
 
     void validateProductName(String name);
 
-    // 발주용 상품 가격 확인
-    int getUnitPrice(Long productId);
+    ProductEntity findProductById(Long id);
+
 }

--- a/src/main/java/com/project/chaechaeserver/domain/service/products/ProductDomainServiceImpl.java
+++ b/src/main/java/com/project/chaechaeserver/domain/service/products/ProductDomainServiceImpl.java
@@ -1,5 +1,6 @@
 package com.project.chaechaeserver.domain.service.products;
 
+import com.project.chaechaeserver.domain.model.products.ProductEntity;
 import com.project.chaechaeserver.domain.repository.products.ProductsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -8,20 +9,19 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ProductDomainServiceImpl implements ProductDomainService {
 
-    private final ProductsRepository productsRepository;
+  private final ProductsRepository productsRepository;
 
-    @Override
-    public void validateProductName(String name) {
-        if (productsRepository.existsByName(name)) {
-            throw new IllegalArgumentException("이미 존재하는 상품명입니다: " + name);
-        }
+  @Override
+  public void validateProductName(String name) {
+    if (productsRepository.existsByName(name)) {
+      throw new IllegalArgumentException("이미 존재하는 상품명입니다: " + name);
     }
+  }
 
-    // 발주용 상품 가격 확인
-    @Override
-    public int getUnitPrice(Long productId) {
-        return productsRepository.findById(productId)
-            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 상품입니다."))
-            .getPrice();
-    }
+  @Override
+  public ProductEntity findProductById(Long id) {
+    return productsRepository.findById(id)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 상품입니다."));
+  }
+
 }

--- a/src/main/java/com/project/chaechaeserver/infrastructure/config/AuditorConfig.java
+++ b/src/main/java/com/project/chaechaeserver/infrastructure/config/AuditorConfig.java
@@ -1,0 +1,32 @@
+package com.project.chaechaeserver.infrastructure.config;
+
+import java.util.Optional;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@Configuration
+public class AuditorConfig {
+
+  @Bean
+  public AuditorAware<String> auditorProvider() {
+    return new AuditorAwareImpl();
+  }
+
+
+  static class AuditorAwareImpl implements AuditorAware<String> {
+
+    @Override
+    public Optional<String> getCurrentAuditor() {
+      Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+      if (authentication == null || !authentication.isAuthenticated()) {
+        return Optional.empty();
+      }
+
+      return Optional.ofNullable(authentication.getName());
+    }
+  }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- ex) #50

## 📝 Description

- 상품 직접 참조 대신 값 객체(ProductInfo)로 주문 시점의 상품 정보를 스냅샷처럼 보존하도록 변경했습니다.
   -> 발주 시 한 번만 상품을 조회해 의존성을 줄이고, 이후에도 일관된 정보 유지를 가능하게 했습니다.
- 단일 가격은 변동 가능성을 고려하여, 기존 필드를 유지하도록 했습니다.
- 상태값 중 '요청'을 제거하고, 발주 생성 시 기본 상태를 '승인'으로 변경했습니다.
- 상품 ID를 통해 상품의 이름, 카테고리, 가격을 조회하도록 설정했습니다.
- 생성자, 수정자, 삭제자 필드를 추가하고, 이를 위해 JPA Auditor 설정을 적용했습니다.

<img width="289" height="299" alt="스크린샷 2025-07-19 오후 9 07 30" src="https://github.com/user-attachments/assets/7733e1bb-8911-4f66-9ca5-2f358d6fcb0a" />



## 💬 To Reivewers

- 이상한 부분 혹은 개선이 필요하다고 생각되시는 부분이 있다면 편하게 말씀 부탁드립니다. 감사합니다.