### PR TITLE
[ FEAT ] 스프링부트 ↔ FastAPI 챗봇 연동 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,9 +41,11 @@ dependencies {
 
     // Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
+
     //prometheus
     implementation group: 'org.springframework.boot', name: 'spring-boot-starter-actuator', version: '3.1.6'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
     // Jwt
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
@@ -53,6 +55,7 @@ dependencies {
     implementation group: 'org.springdoc', name: 'springdoc-openapi-starter-webmvc-ui', version: '2.7.0'
 
     // Web, Lombok, Valid, Test
+    implementation("org.apache.httpcomponents.client5:httpclient5:5.5")
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/project/chaechaeserver/application/response/chatbot/ResChatbotPostAnswerDTO.java
+++ b/src/main/java/com/project/chaechaeserver/application/response/chatbot/ResChatbotPostAnswerDTO.java
@@ -1,0 +1,16 @@
+package com.project.chaechaeserver.application.response.chatbot;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResChatbotPostAnswerDTO {
+
+    private String answer;
+
+}

--- a/src/main/java/com/project/chaechaeserver/application/response/chatbot/ResChatbotPostAnswerDTO.java
+++ b/src/main/java/com/project/chaechaeserver/application/response/chatbot/ResChatbotPostAnswerDTO.java
@@ -1,5 +1,6 @@
 package com.project.chaechaeserver.application.response.chatbot;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,6 +12,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ResChatbotPostAnswerDTO {
 
+    @Schema(example = "시금치는 냉장보관을 합니다.")
     private String answer;
 
 }

--- a/src/main/java/com/project/chaechaeserver/application/service/chatbot/ChatbotService.java
+++ b/src/main/java/com/project/chaechaeserver/application/service/chatbot/ChatbotService.java
@@ -1,0 +1,39 @@
+package com.project.chaechaeserver.application.service.chatbot;
+
+import com.project.chaechaeserver.application.response.chatbot.ResChatbotPostAnswerDTO;
+import com.project.chaechaeserver.presentation.request.chatbot.ReqChatbotPostQuestionDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@Service
+@RequiredArgsConstructor
+public class ChatbotService {
+
+    @Value("${chatbot.base-url.fast-api}")
+    private String baseUrl;
+
+    public final RestClient restClient;
+
+    public ResChatbotPostAnswerDTO ask(ReqChatbotPostQuestionDTO dto) {
+
+        URI uri = UriComponentsBuilder
+                .fromUriString(baseUrl)
+                .path("/rag/ask")
+                .encode()
+                .build()
+                .toUri();
+
+        return restClient.post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(dto)
+                .retrieve()
+                .body(ResChatbotPostAnswerDTO.class);
+    }
+}

--- a/src/main/java/com/project/chaechaeserver/application/service/chatbot/ChatbotService.java
+++ b/src/main/java/com/project/chaechaeserver/application/service/chatbot/ChatbotService.java
@@ -2,38 +2,8 @@ package com.project.chaechaeserver.application.service.chatbot;
 
 import com.project.chaechaeserver.application.response.chatbot.ResChatbotPostAnswerDTO;
 import com.project.chaechaeserver.presentation.request.chatbot.ReqChatbotPostQuestionDTO;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.MediaType;
-import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestClient;
-import org.springframework.web.util.UriComponentsBuilder;
 
-import java.net.URI;
+public interface ChatbotService {
 
-@Service
-@RequiredArgsConstructor
-public class ChatbotService {
-
-    @Value("${chatbot.base-url.fast-api}")
-    private String baseUrl;
-
-    public final RestClient restClient;
-
-    public ResChatbotPostAnswerDTO ask(ReqChatbotPostQuestionDTO dto) {
-
-        URI uri = UriComponentsBuilder
-                .fromUriString(baseUrl)
-                .path("/rag/ask")
-                .encode()
-                .build()
-                .toUri();
-
-        return restClient.post()
-                .uri(uri)
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(dto)
-                .retrieve()
-                .body(ResChatbotPostAnswerDTO.class);
-    }
+    ResChatbotPostAnswerDTO ask(ReqChatbotPostQuestionDTO dto);
 }

--- a/src/main/java/com/project/chaechaeserver/application/service/chatbot/ChatbotServiceImpl.java
+++ b/src/main/java/com/project/chaechaeserver/application/service/chatbot/ChatbotServiceImpl.java
@@ -1,0 +1,39 @@
+package com.project.chaechaeserver.application.service.chatbot;
+
+import com.project.chaechaeserver.application.response.chatbot.ResChatbotPostAnswerDTO;
+import com.project.chaechaeserver.presentation.request.chatbot.ReqChatbotPostQuestionDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@Service
+@RequiredArgsConstructor
+public class ChatbotServiceImpl implements ChatbotService {
+
+    @Value("${chatbot.base-url.fast-api}")
+    private String baseUrl;
+
+    public final RestClient restClient;
+
+    public ResChatbotPostAnswerDTO ask(ReqChatbotPostQuestionDTO dto) {
+
+        URI uri = UriComponentsBuilder
+                .fromUriString(baseUrl)
+                .path("/rag/ask")
+                .encode()
+                .build()
+                .toUri();
+
+        return restClient.post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(dto)
+                .retrieve()
+                .body(ResChatbotPostAnswerDTO.class);
+    }
+}

--- a/src/main/java/com/project/chaechaeserver/infrastructure/chatbot/docs/ChatbotControllerSwagger.java
+++ b/src/main/java/com/project/chaechaeserver/infrastructure/chatbot/docs/ChatbotControllerSwagger.java
@@ -1,0 +1,29 @@
+package com.project.chaechaeserver.infrastructure.chatbot.docs;
+
+import com.project.chaechaeserver.application.global.dto.ResDTO;
+import com.project.chaechaeserver.application.response.chatbot.ResChatbotPostAnswerDTO;
+import com.project.chaechaeserver.presentation.request.chatbot.ReqChatbotPostQuestionDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "Chatbot", description = "챗봇 관련 API를 제공합니다.")
+@RequestMapping("/api/chat")
+public interface ChatbotControllerSwagger {
+
+    @Operation(summary = "질의 생성", description = "질의를 생성하는 API 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "질의 생성 성공", content = @Content(schema = @Schema(implementation = ResChatbotPostAnswerDTO.class))),
+            @ApiResponse(responseCode = "400", description = "질의 생성 실패", content = @Content(schema = @Schema(implementation = ResDTO.class)))
+    })
+    @PostMapping("/ask")
+    ResponseEntity<ResDTO<ResChatbotPostAnswerDTO>> ask(@Valid @RequestBody ReqChatbotPostQuestionDTO dto);
+}

--- a/src/main/java/com/project/chaechaeserver/infrastructure/config/HttpClientConfig.java
+++ b/src/main/java/com/project/chaechaeserver/infrastructure/config/HttpClientConfig.java
@@ -1,0 +1,24 @@
+package com.project.chaechaeserver.infrastructure.config;
+
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.apache.hc.client5.http.impl.DefaultConnectionKeepAliveStrategy;
+import org.apache.hc.client5.http.impl.classic.DefaultBackoffStrategy;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.impl.DefaultConnectionReuseStrategy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class HttpClientConfig {
+
+    @Bean
+    public HttpClient httpClient() {
+        return HttpClients.custom()
+                .setConnectionReuseStrategy(DefaultConnectionReuseStrategy.INSTANCE)
+                .setKeepAliveStrategy(new DefaultConnectionKeepAliveStrategy())
+                .setConnectionBackoffStrategy(new DefaultBackoffStrategy())
+                .evictExpiredConnections()
+                .build();
+    }
+
+}

--- a/src/main/java/com/project/chaechaeserver/infrastructure/config/RestClientConfig.java
+++ b/src/main/java/com/project/chaechaeserver/infrastructure/config/RestClientConfig.java
@@ -1,0 +1,20 @@
+package com.project.chaechaeserver.infrastructure.config;
+
+import org.apache.hc.client5.http.classic.HttpClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public RestClient restClient(HttpClient httpClient) {
+        return RestClient.builder()
+                .requestFactory(new HttpComponentsClientHttpRequestFactory(httpClient))
+                .build();
+    }
+
+}

--- a/src/main/java/com/project/chaechaeserver/infrastructure/config/SecurityConfig.java
+++ b/src/main/java/com/project/chaechaeserver/infrastructure/config/SecurityConfig.java
@@ -64,7 +64,7 @@ public class SecurityConfig {
                 authorizeHttpRequests
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
                         .requestMatchers("/").permitAll()
-                        .requestMatchers("//api/users/login").permitAll()
+                        .requestMatchers("/api/users/login").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources/**").permitAll()
                         .anyRequest().authenticated()
         );

--- a/src/main/java/com/project/chaechaeserver/presentation/controller/chatbot/ChatbotController.java
+++ b/src/main/java/com/project/chaechaeserver/presentation/controller/chatbot/ChatbotController.java
@@ -1,0 +1,41 @@
+package com.project.chaechaeserver.presentation.controller.chatbot;
+
+import com.project.chaechaeserver.application.global.constants.ResCode;
+import com.project.chaechaeserver.application.global.dto.ResDTO;
+import com.project.chaechaeserver.application.response.chatbot.ResChatbotPostAnswerDTO;
+import com.project.chaechaeserver.application.service.chatbot.ChatbotService;
+import com.project.chaechaeserver.presentation.request.chatbot.ReqChatbotPostQuestionDTO;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.project.chaechaeserver.domain.model.user.constraint.RoleType.Role.ADMIN;
+import static com.project.chaechaeserver.domain.model.user.constraint.RoleType.Role.EMPLOYEE;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chat")
+public class ChatbotController {
+
+    private final ChatbotService chatbotService;
+
+    @PostMapping("/ask")
+    @Secured({ADMIN, EMPLOYEE})
+    public ResponseEntity<ResDTO<ResChatbotPostAnswerDTO>> ask(@Valid @RequestBody ReqChatbotPostQuestionDTO dto) {
+
+        return new ResponseEntity<>(
+                ResDTO.<ResChatbotPostAnswerDTO>builder()
+                        .code(ResCode.OK)
+                        .message("질문 응답 완료")
+                        .data(chatbotService.ask(dto))
+                        .build(),
+                HttpStatus.OK
+        );
+    }
+}

--- a/src/main/java/com/project/chaechaeserver/presentation/request/chatbot/ReqChatbotPostQuestionDTO.java
+++ b/src/main/java/com/project/chaechaeserver/presentation/request/chatbot/ReqChatbotPostQuestionDTO.java
@@ -1,5 +1,6 @@
 package com.project.chaechaeserver.presentation.request.chatbot;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -12,6 +13,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ReqChatbotPostQuestionDTO {
 
+    @Schema(example = "시금치의 보관방법을 알려주세요")
     @NotBlank(message = "질문을 입력해주세요.")
     private String question;
 

--- a/src/main/java/com/project/chaechaeserver/presentation/request/chatbot/ReqChatbotPostQuestionDTO.java
+++ b/src/main/java/com/project/chaechaeserver/presentation/request/chatbot/ReqChatbotPostQuestionDTO.java
@@ -1,0 +1,18 @@
+package com.project.chaechaeserver.presentation.request.chatbot;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReqChatbotPostQuestionDTO {
+
+    @NotBlank(message = "질문을 입력해주세요.")
+    private String question;
+
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -31,3 +31,7 @@ service:
 
 springdoc:
   use-fqn: true
+
+chatbot:
+  base-url:
+    fast-api: http://127.0.0.1:8000


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #66 

## 📝 Description

- 스프링부트 서비스에서 파이썬 FastAPI 챗봇(`POST /rag/ask`)을 호출하기 위해 **RestClient** 클라이언트를 도입하여 구현했습니다.

### 요청 예시
```json
{
  "question": "채채봇은 어떤 서비스를 제공하나요?"
}
```

### 응답 예시
```json
{
    "code": 1,
    "message": "질문 응답 완료",
    "data": {
        "answer": "채채봇은 다음과 같은 서비스를 제공합니다:\n- 주문 현황 확인\n- 재고 부족 알림\n- 발주 자동화 지원\n- 배송 지연 알림\n- 고객 문의에 대한 템플릿 제공\n- 지식 검색 (FAQ 및 매뉴얼 포함..."
    }
}
```
