### PR TITLE
스프링부트 ↔ 파이썬 파일 업로드 REST 연동

### DIFF
--- a/src/main/java/com/project/chaechaeserver/application/response/dataset/ResDatasetPostPreSignedUrlDTO.java
+++ b/src/main/java/com/project/chaechaeserver/application/response/dataset/ResDatasetPostPreSignedUrlDTO.java
@@ -1,0 +1,17 @@
+package com.project.chaechaeserver.application.response.dataset;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResDatasetPostPreSignedUrlDTO {
+
+    private String key;
+    private String upload_url;
+
+}

--- a/src/main/java/com/project/chaechaeserver/application/response/dataset/ResDatasetPostPreSignedUrlDTO.java
+++ b/src/main/java/com/project/chaechaeserver/application/response/dataset/ResDatasetPostPreSignedUrlDTO.java
@@ -1,5 +1,6 @@
 package com.project.chaechaeserver.application.response.dataset;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +12,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ResDatasetPostPreSignedUrlDTO {
 
+    @Schema(example = "datasets/2025/09/24/채채봇/ce8abe89")
     private String key;
+
+    @Schema(example = "http://localhost:9000/demo-bucket/datasets/2025/09/24/%EC%B1%84%EC%B1%84....")
     private String upload_url;
 
 }

--- a/src/main/java/com/project/chaechaeserver/application/service/dataset/DatasetService.java
+++ b/src/main/java/com/project/chaechaeserver/application/service/dataset/DatasetService.java
@@ -1,0 +1,10 @@
+package com.project.chaechaeserver.application.service.dataset;
+
+import com.project.chaechaeserver.application.response.dataset.ResDatasetPostPreSignedUrlDTO;
+import com.project.chaechaeserver.presentation.request.dataset.ReqDatasetPostPreSignedUrlDTO;
+
+public interface DatasetService {
+
+    ResDatasetPostPreSignedUrlDTO generatePreSignedUrl(ReqDatasetPostPreSignedUrlDTO dto);
+
+}

--- a/src/main/java/com/project/chaechaeserver/application/service/dataset/DatasetServiceImpl.java
+++ b/src/main/java/com/project/chaechaeserver/application/service/dataset/DatasetServiceImpl.java
@@ -1,0 +1,39 @@
+package com.project.chaechaeserver.application.service.dataset;
+
+import com.project.chaechaeserver.application.response.dataset.ResDatasetPostPreSignedUrlDTO;
+import com.project.chaechaeserver.presentation.request.dataset.ReqDatasetPostPreSignedUrlDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@Service
+@RequiredArgsConstructor
+public class DatasetServiceImpl implements DatasetService {
+
+    @Value("${chatbot.base-url.fast-api}")
+    private String baseUrl;
+
+    public final RestClient restClient;
+
+    public ResDatasetPostPreSignedUrlDTO generatePreSignedUrl(ReqDatasetPostPreSignedUrlDTO dto) {
+
+        URI uri = UriComponentsBuilder
+                .fromUriString(baseUrl)
+                .path("/v1/datasets/upload")
+                .encode()
+                .build()
+                .toUri();
+
+        return restClient.post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(dto)
+                .retrieve()
+                .body(ResDatasetPostPreSignedUrlDTO.class);
+    }
+}

--- a/src/main/java/com/project/chaechaeserver/infrastructure/dataset/docs/DatasetControllerSwagger.java
+++ b/src/main/java/com/project/chaechaeserver/infrastructure/dataset/docs/DatasetControllerSwagger.java
@@ -1,0 +1,30 @@
+package com.project.chaechaeserver.infrastructure.dataset.docs;
+
+import com.project.chaechaeserver.application.global.dto.ResDTO;
+import com.project.chaechaeserver.application.response.dataset.ResDatasetPostPreSignedUrlDTO;
+import com.project.chaechaeserver.presentation.request.dataset.ReqDatasetPostPreSignedUrlDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "Dataset", description = "파일 업로드 관련 API를 제공합니다.")
+@RequestMapping("/api/dataset")
+public interface DatasetControllerSwagger {
+
+
+    @Operation(summary = "Pre-Signed-Url 생성", description = "Pre-Signed-Url 을 생성하는 API 입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "URL 생성 성공", content = @Content(schema = @Schema(implementation = ResDatasetPostPreSignedUrlDTO.class))),
+            @ApiResponse(responseCode = "400", description = "URL 생성 실패", content = @Content(schema = @Schema(implementation = ResDTO.class)))
+    })
+    @PostMapping
+    ResponseEntity<ResDTO<ResDatasetPostPreSignedUrlDTO>> generatePreSignedUrl(@Valid @RequestBody ReqDatasetPostPreSignedUrlDTO dto);
+}

--- a/src/main/java/com/project/chaechaeserver/presentation/controller/dataset/DatasetController.java
+++ b/src/main/java/com/project/chaechaeserver/presentation/controller/dataset/DatasetController.java
@@ -1,0 +1,41 @@
+package com.project.chaechaeserver.presentation.controller.dataset;
+
+import com.project.chaechaeserver.application.global.constants.ResCode;
+import com.project.chaechaeserver.application.global.dto.ResDTO;
+import com.project.chaechaeserver.application.response.dataset.ResDatasetPostPreSignedUrlDTO;
+import com.project.chaechaeserver.application.service.dataset.DatasetService;
+import com.project.chaechaeserver.presentation.request.dataset.ReqDatasetPostPreSignedUrlDTO;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.project.chaechaeserver.domain.model.user.constraint.RoleType.Role.ADMIN;
+import static com.project.chaechaeserver.domain.model.user.constraint.RoleType.Role.EMPLOYEE;
+
+@RestController
+@RequestMapping("/api/dataset")
+@RequiredArgsConstructor
+public class DatasetController {
+
+    private final DatasetService datasetService;
+
+    @PostMapping
+    @Secured({ADMIN, EMPLOYEE})
+    public ResponseEntity<ResDTO<ResDatasetPostPreSignedUrlDTO>> generatePreSignedUrl(@Valid @RequestBody ReqDatasetPostPreSignedUrlDTO dto) {
+
+        return new ResponseEntity<>(
+                ResDTO.<ResDatasetPostPreSignedUrlDTO>builder()
+                        .code(ResCode.CREATED)
+                        .message("Pre-Signed-Url 발급 완료")
+                        .data(datasetService.generatePreSignedUrl(dto))
+                        .build(),
+                HttpStatus.CREATED
+        );
+    }
+}

--- a/src/main/java/com/project/chaechaeserver/presentation/request/dataset/ReqDatasetPostPreSignedUrlDTO.java
+++ b/src/main/java/com/project/chaechaeserver/presentation/request/dataset/ReqDatasetPostPreSignedUrlDTO.java
@@ -1,0 +1,20 @@
+package com.project.chaechaeserver.presentation.request.dataset;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReqDatasetPostPreSignedUrlDTO {
+
+    @Schema(example = "채채봇 매뉴얼.pdf")
+    @NotBlank(message = "파일명을 입력해주세요.")
+    private String filename;
+
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #68 

## 📝 Description

- FastAPI의 **Pre-Signed URL** 발급 엔드포인트와 스프링 부트 서버가 통신할 수 있도록 연동 API를 구현했습니다.

### 요청 예시
```json
{
    "filename" : "채채봇"
}
```

### 응답 예시
```json
{
    "code": 1,
    "message": "Pre-Signed-Url 발급 완료",
    "data": {
        "key": "datasets/2025/09/24/채채봇/ce8abe89",
        "upload_url": "http://localhost:9000/demo-bucket/datasets/2025/09/24/%EC%B1%84%..."
    }
}
```
